### PR TITLE
Ignore running and none result on the problems view

### DIFF
--- a/app/models/obs_factory/openqa_job.rb
+++ b/app/models/obs_factory/openqa_job.rb
@@ -89,7 +89,7 @@ module ObsFactory
     #
     # @return [Array] array of module names
     def failing_modules
-      modules.reject {|m| %w(passed).include? m['result']}.map {|m| m['name'] }
+      modules.reject {|m| %w(passed running none).include? m['result']}.map {|m| m['name'] }
     end
 
     # Result of the job, or its state if no result is available yet


### PR DESCRIPTION
Only reject passed job module is not enough, staging dashboard will
shows running job module on the problems view. And job module with
none result should be the module not running yet, ignore it as well.