### PR TITLE
Don't hardcode ISO architecture for stagings

### DIFF
--- a/app/models/obs_factory/distribution.rb
+++ b/app/models/obs_factory/distribution.rb
@@ -43,7 +43,7 @@ module ObsFactory
     end
 
     def_delegators :@strategy, :root_project_name, :url_suffix, :openqa_version,
-                               :openqa_iso_prefix
+                               :openqa_iso_prefix, :arch
 
     # Find a distribution by id
     #

--- a/app/models/obs_factory/distribution_strategy_factory.rb
+++ b/app/models/obs_factory/distribution_strategy_factory.rb
@@ -24,6 +24,10 @@ module ObsFactory
       'images/local/_product:openSUSE-cd-mini-x86_64'
     end
 
+    def arch
+      'x86_64'
+    end
+
     def url_suffix
       'factory/iso'
     end

--- a/app/models/obs_factory/distribution_strategy_factory_ppc.rb
+++ b/app/models/obs_factory/distribution_strategy_factory_ppc.rb
@@ -11,6 +11,10 @@ module ObsFactory
       'images/local/_product:openSUSE-cd-mini-ppc64le'
     end
 
+    def arch
+      'ppc64le'
+    end
+
     def url_suffix
       'ports/ppc/factory'
     end

--- a/app/models/obs_factory/staging_project.rb
+++ b/app/models/obs_factory/staging_project.rb
@@ -221,8 +221,9 @@ module ObsFactory
     # @return [String] file name
     def iso
       return @iso if @iso
-      buildresult = Buildresult.find_hashed(project: name, package: 'Test-DVD-x86_64',
-                                            repository: 'images', arch: 'x86_64',
+      arch = distribution.arch
+      buildresult = Buildresult.find_hashed(project: name, package: "Test-DVD-#{arch}",
+                                            repository: 'images', arch: "#{arch}",
                                             view: 'binarylist')
       binaries = buildresult['result']['binarylist']['binary']
       return nil if binaries.nil?
@@ -230,7 +231,7 @@ module ObsFactory
       return nil if binary.nil?
       ending = binary['filename'][5..-1] # Everything but the initial 'Test-'
       suffix = /DVD$/ =~ name ? 'Staging2' : 'Staging'
-      @iso = distribution.openqa_iso_prefix + ":#{letter}-#{suffix}-DVD-x86_64-#{ending}"
+      @iso = distribution.openqa_iso_prefix + ":#{letter}-#{suffix}-DVD-#{arch}-#{ending}"
     end
 
     def self.attributes


### PR DESCRIPTION
This patch allows to query ppc64le ISOs as well

Signed-off-by: Dinar Valeev <dvaleev@suse.com>