### PR TITLE
Limit the dashboard's openQA result to the right openqa group id

### DIFF
--- a/app/models/obs_factory/distribution.rb
+++ b/app/models/obs_factory/distribution.rb
@@ -45,6 +45,10 @@ module ObsFactory
       matchdata[1]
     end
 
+    def openqa_groupid
+      '1'
+    end
+
     def openqa_iso_prefix
       "openSUSE-Staging"
     end

--- a/app/views/obs_factory/distributions/show.html.haml
+++ b/app/views/obs_factory/distributions/show.html.haml
@@ -89,7 +89,7 @@
 
     %h2
       %i{class: "fa fa-2 fa-wrench"}
-      = link_to "openQA results for #{@versions[:totest]}", "https://openqa.opensuse.org/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&build=#{@versions[:totest]}"
+      = link_to "openQA results for #{@versions[:totest]}", "https://openqa.opensuse.org/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&build=#{@versions[:totest]}&groupid=#{@distribution.openqa_groupid}"
 
     %p
       - @openqa_jobs.group_by(&:result_or_state).each do |label, jobs|


### PR DESCRIPTION
Not sure if I ot this all right (can I test this somehow) - but at least from reading through what else we have in here, this should be about the right thing.

/dashboard currently shows often wrong info (it mixes PPC openqa results in)