### PR TITLE
Expand link for source_version

### DIFF
--- a/app/models/obs_factory/distribution.rb
+++ b/app/models/obs_factory/distribution.rb
@@ -126,7 +126,7 @@ module ObsFactory
     def source_version
       Rails.cache.fetch("source_version_for_#{name}", expires_in: 10.minutes) do
         begin
-          p = Xmlhash.parse(ActiveXML::backend.direct_http "/source/#{name}/#{SOURCE_VERSION_FILE}")
+          p = Xmlhash.parse(ActiveXML::backend.direct_http "/source/#{name}/#{SOURCE_VERSION_FILE}?expand=1")
           p.get('products').get('product').get('version')
         rescue ActiveXML::Transport::NotFoundError
           nil


### PR DESCRIPTION
direct_http needs expansion in order to get source version
from linked modified _product

https://lists.opensuse.org/opensuse-buildservice/2016-03/msg00080.html

Signed-off-by: Dinar Valeev <dvaleev@suse.com>